### PR TITLE
chore: rename mod

### DIFF
--- a/avm/avm.go
+++ b/avm/avm.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/giuliop/HermesVault-smartcontracts/deployed"
+	"github.com/joe-p/Mithras-Protocol/deployed"
 
 	"github.com/algorand/go-algorand-sdk/v2/abi"
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/algod"

--- a/avm/config.go
+++ b/avm/config.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/giuliop/HermesVault-smartcontracts/deployed"
-	"github.com/giuliop/HermesVault-smartcontracts/encrypt"
+	"github.com/joe-p/Mithras-Protocol/deployed"
+	"github.com/joe-p/Mithras-Protocol/encrypt"
 
 	"github.com/algorand/go-algorand-sdk/v2/client/kmd"
 	"github.com/algorand/go-algorand-sdk/v2/crypto"

--- a/circuits/withdrawal_circuit.go
+++ b/circuits/withdrawal_circuit.go
@@ -3,7 +3,7 @@ package circuits
 import (
 	"runtime"
 
-	"github.com/giuliop/HermesVault-smartcontracts/config"
+	"github.com/joe-p/Mithras-Protocol/config"
 
 	tedwards "github.com/consensys/gnark-crypto/ecc/twistededwards"
 	"github.com/consensys/gnark/frontend"

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/giuliop/HermesVault-smartcontracts/mimc"
+	"github.com/joe-p/Mithras-Protocol/mimc"
 
 	"github.com/consensys/gnark-crypto/ecc"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giuliop/HermesVault-smartcontracts
+module github.com/joe-p/Mithras-Protocol
 
 go 1.23.0
 

--- a/main.go
+++ b/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/giuliop/HermesVault-smartcontracts/deployed"
-	"github.com/giuliop/HermesVault-smartcontracts/setup"
+	"github.com/joe-p/Mithras-Protocol/deployed"
+	"github.com/joe-p/Mithras-Protocol/setup"
 )
 
 func main() {

--- a/setup/init.go
+++ b/setup/init.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/giuliop/HermesVault-smartcontracts/circuits"
+	"github.com/joe-p/Mithras-Protocol/circuits"
 
 	"github.com/consensys/gnark/frontend"
 )

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/giuliop/HermesVault-smartcontracts/avm"
-	"github.com/giuliop/HermesVault-smartcontracts/config"
-	"github.com/giuliop/HermesVault-smartcontracts/deployed"
+	"github.com/joe-p/Mithras-Protocol/avm"
+	"github.com/joe-p/Mithras-Protocol/config"
+	"github.com/joe-p/Mithras-Protocol/deployed"
 
 	"github.com/consensys/gnark-crypto/ecc"
 

--- a/test/ecies_test.go
+++ b/test/ecies_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards/eddsa"
-	"github.com/giuliop/HermesVault-smartcontracts/encrypt"
+	"github.com/joe-p/Mithras-Protocol/encrypt"
 )
 
 func TestECIESEncryptDecrypt(t *testing.T) {

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -9,10 +9,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/giuliop/HermesVault-smartcontracts/avm"
-	"github.com/giuliop/HermesVault-smartcontracts/config"
-	"github.com/giuliop/HermesVault-smartcontracts/deployed"
-	"github.com/giuliop/HermesVault-smartcontracts/setup"
+	"github.com/joe-p/Mithras-Protocol/avm"
+	"github.com/joe-p/Mithras-Protocol/config"
+	"github.com/joe-p/Mithras-Protocol/deployed"
+	"github.com/joe-p/Mithras-Protocol/setup"
 
 	"github.com/algorand/go-algorand-sdk/v2/crypto"
 	"github.com/algorand/go-algorand-sdk/v2/transaction"

--- a/test/merkle.go
+++ b/test/merkle.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 
-	"github.com/giuliop/HermesVault-smartcontracts/config"
+	"github.com/joe-p/Mithras-Protocol/config"
 )
 
 type Tree struct {

--- a/test/merkle_test.go
+++ b/test/merkle_test.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/giuliop/HermesVault-smartcontracts/config"
+	"github.com/joe-p/Mithras-Protocol/config"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"

--- a/test/setup.go
+++ b/test/setup.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/giuliop/HermesVault-smartcontracts/config"
-	"github.com/giuliop/HermesVault-smartcontracts/setup"
+	"github.com/joe-p/Mithras-Protocol/config"
+	"github.com/joe-p/Mithras-Protocol/setup"
 
 	"github.com/algorand/go-algorand-sdk/v2/crypto"
 	"github.com/giuliop/algoplonk/utils"

--- a/test/testing.go
+++ b/test/testing.go
@@ -15,10 +15,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards/eddsa"
 	"github.com/consensys/gnark-crypto/ecc/twistededwards"
 
-	"github.com/giuliop/HermesVault-smartcontracts/avm"
-	"github.com/giuliop/HermesVault-smartcontracts/circuits"
-	"github.com/giuliop/HermesVault-smartcontracts/config"
-	"github.com/giuliop/HermesVault-smartcontracts/encrypt"
+	"github.com/joe-p/Mithras-Protocol/avm"
+	"github.com/joe-p/Mithras-Protocol/circuits"
+	"github.com/joe-p/Mithras-Protocol/config"
+	"github.com/joe-p/Mithras-Protocol/encrypt"
 
 	"github.com/algorand/go-algorand-sdk/v2/abi"
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/common/models"


### PR DESCRIPTION
## Summary by Sourcery

Rename the Go module to github.com/joe-p/Mithras-Protocol and update all imports to reflect the new path

Build:
- Update module path in go.mod to github.com/joe-p/Mithras-Protocol

Chores:
- Adjust import statements across all packages to use the renamed module path